### PR TITLE
Fix start-block init and add START_BLOCK env var

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -29,7 +29,6 @@ const checkBlockNum = async () => {
     process.exit();
   }
 };
-checkBlockNum();
 
 let isRunning = false;
 const tick = async () => {
@@ -40,6 +39,7 @@ const tick = async () => {
 
   console.log(`${new Date().toLocaleString()} Ticking...`);
 
+  await checkBlockNum();
   const lastBlockAlerted = await getLastBlockAlerted();
   if (!lastBlockAlerted) {
     throw new Error(`No last block set`);

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -23,7 +23,7 @@ const alertForBlocks = async (fromBlock: number) => {
 const checkBlockNum = async () => {
   const lastBlockNum = await getLastBlockAlerted();
   if (!lastBlockNum) {
-    const blockNumber = 12862631;
+    const blockNumber = process.env.START_BLOCK && Number(process.env.START_BLOCK) || 12862631;
     await setLastBlockAlerted(blockNumber);
     console.info(`Block number set to latest ${blockNumber} -- restart`);
     process.exit();


### PR DESCRIPTION
 Wait for checkBlockNum() and avoid exceptions

If value is not set, will now correctly print out `block num set - please restart` rather than throwing an error

Allow configuring start block with START_BLOCK, defaults to existing value set in code
