### PR TITLE
Use REDIS_DB env var to set the redis DB slot

### DIFF
--- a/app/src/redis_util.ts
+++ b/app/src/redis_util.ts
@@ -6,6 +6,7 @@ console.log("host", process.env.REDIS_HOST);
 const redisClient = redis.createClient({
   host: process.env.REDIS_HOST || "redis",
   port: 6379,
+  db: process.env.REDIS_DB || 0,
 });
 
 const getAsyncRaw = promisify(redisClient.get);


### PR DESCRIPTION
Don't cross the streams unless you meant to cross the streams

Optional and defaults to 0
