### PR TITLE
fix(): prevent "undefined" string for unsupported events

### DIFF
--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -117,8 +117,12 @@ const getEventText = async (event: PartyEvent): Promise<string | undefined> => {
       } else {
         return undefined;
       }
+    case "bid":
+    case "start":
+      // no tweet text defined for these events
+      return undefined;
     default:
-      console.error("Unknown event", event);
+      console.error("twitter.ts::Unknown event", event);
       return undefined;
   }
 };

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -85,7 +85,7 @@ const getTwitterHandleOrNameFromEvent = async (
   }
 };
 
-const eventText = async (event: PartyEvent): Promise<string | undefined> => {
+const getEventText = async (event: PartyEvent): Promise<string | undefined> => {
   const partyDesc = `${event.party.name} (${event.party.symbol})`;
   const creatorName = await bestUserName(event.party.createdBy);
   const twitterHandleOrName = await getTwitterHandleOrNameFromEvent(event);
@@ -129,13 +129,13 @@ export const postTweetIfRelevant = async (event: PartyEvent) => {
     return;
   }
 
-  let tweetText = "";
-  tweetText += await eventText(event);
+  const eventText = await getEventText(event);
   // do not tweet if the event is unknown
-  if (!tweetText) {
+  if (!eventText) {
     return;
   }
 
+  let tweetText = eventText;
   if (
     event.eventType === "contribution" ||
     event.eventType === "finalization"


### PR DESCRIPTION
the function that creates the tweet text for each event returns `undefined`. the place that uses that function creates a string from the result, regardless of the result is, by adding `let tweetText = "" + eventText`.

if `eventText` is undefined, then `tweetText` will be the string `"undefined"`