### PR TITLE
fix(): special case opensea asset fetch for collection parties

### DIFF
--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -21,9 +21,11 @@ const getOpenseaCollection = async (
   const {
     party: { nftContractAddress, nftTokenId },
   } = event;
+  // collection buys do not have an associated nftTokenId. in this case, we default to tokenId 1
+  const tokenId = nftTokenId ? nftTokenId : 1;
   try {
     const r = await axios.get(
-      `https://api.opensea.io/api/v1/asset/${nftContractAddress}/${nftTokenId}`,
+      `https://api.opensea.io/api/v1/asset/${nftContractAddress}/${tokenId}`,
       {
         headers: {
           "X-API-KEY": config.openSeaApiKey,


### PR DESCRIPTION
collection parties do not have a tokenId set, so `nftTokenId` will be `undefined` (or `null`?). in this case we are calling the opensea api with a `null` `nftTokenId`.

there is no opensea api to get a collection's info based on the collection's nft address. so we first fetch a single asset from the collection by making a request for a specific nft token id for a specific collection, and then reading the `collection` property of the result.

my patch is to fall back to a token id of `1` if no `nftTokenId` is present. (kind of a meh solution to this problem.)
another possible solution is `if (event.party.partyType === 'collection') { /* default tokenId  to 1 */ }`

if we do not like default the token id to 1, we could instead use the gem api

### screenshots
|before|after|
|--|--|
|<img width="587" alt="Screen Shot 2022-02-11 at 4 20 46 PM" src="https://user-images.githubusercontent.com/2160046/153687717-4dc2903b-d5dc-4c8a-aa91-69b80e3e95bf.png">|<img width="1056" alt="Screen Shot 2022-02-11 at 4 19 56 PM" src="https://user-images.githubusercontent.com/2160046/153687633-d5553a42-0f52-49be-a20c-7e07611604d7.png">|