### PR TITLE
fix(): update PARTYBID_API_BASE env var

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export const config = {
     "opensea api key"
   ),
   partybidApiBase: stringFromENVorThrow(
-    process.env.PARTYBID_API_BASE || "https://partybid.app/api",
+    process.env.PARTYBID_API_BASE || "https://www.partybid.app/api",
     "partybid api base"
   ),
 };


### PR DESCRIPTION
* change PARTYBID_API_BASE from `https://partybid.app/api` to `https://www.partybid.app/api`

without the `www.` we were getting `308 REDIRECT` errors, and our api requests were failing.