### PR TITLE
feat(): add logic addresses for proxy verification call

### DIFF
--- a/src/etherscan/constants.ts
+++ b/src/etherscan/constants.ts
@@ -1,3 +1,10 @@
+// NOTE: these must stay up-to-date with the latest party factory contracts https://github.com/PartyDAO/partybid/tree/main/deploy
+export const partyLogicAddresses = Object.freeze({
+  bid: "0x744c2be04d079eddb21c1a9bb13bb5259a368614",
+  buy: "0x2045427276b2ad409202eea1e0c81e150f3203e4",
+  collection: "0x0c696f63a8cfd4b456f725f1174f1d5b48d1e876",
+});
+
 // source code for NonReceivableInitializedProxySourceCode from https://github.com/PartyDAO/partybid/blob/main/contracts/NonReceivableInitializedProxy.sol
 // todo: should we download this from github rather than hardcode it?
 export const NonReceivableInitializedProxySourceCode = `// SPDX-License-Identifier: MIT

--- a/src/etherscan/verifyCollectionPartyContract.ts
+++ b/src/etherscan/verifyCollectionPartyContract.ts
@@ -1,7 +1,10 @@
 import axios from "axios";
 import { PartyEvent } from "types";
 import { config } from "../config";
-import { NonReceivableInitializedProxySourceCode } from "./constants";
+import {
+  partyLogicAddresses,
+  NonReceivableInitializedProxySourceCode,
+} from "./constants";
 
 /**
  * This module verifies the NonReceivableInitializedProxy contract for collection parties. The following steps
@@ -160,7 +163,7 @@ export const verifyCollectionParty = async (
   );
 
   // NOTE: this must match the logic variable of the deployed CollectionPartyFactory contract https://github.com/PartyDAO/partybid/blob/main/contracts/CollectionPartyFactory.sol#L32
-  const logicAddress = "0x0c696f63a8cfd4b456f725f1174f1d5b48d1e876";
+  const logicAddress = partyLogicAddresses.collection;
   const logicAddressHexEncoded = `000000000000000000000000${logicAddress.replace(
     "0x",
     ""


### PR DESCRIPTION
add logic contract addresses for each party type to be used when verifying the proxy contract

### logic addresses
* bid - https://github.com/PartyDAO/partybid/blob/main/deploy/partybid/deployed-contracts/mainnet.json#L4
* buy - https://github.com/PartyDAO/partybid/blob/main/deploy/partybuy/deployed-contracts/mainnet.json#L4
* collection - https://github.com/PartyDAO/partybid/blob/main/deploy/collection-party/deployed-contracts/mainnet.json#L5

etherscan api: https://docs.etherscan.io/api-endpoints/contracts#verify-proxy-contract