### PR TITLE
feat(): add etherscan verification to redis and prevent successive api calls

### DIFF
--- a/src/etherscan/helpers.ts
+++ b/src/etherscan/helpers.ts
@@ -1,0 +1,59 @@
+import {
+  getEtherscanVerifyContractGuidKey,
+  getEtherscanVerifyProxyContractGuidKey,
+} from "../redis_key_util";
+import { getRedisAsync, setRedisAsync } from "../redis_util";
+
+export const getEtherscanVerifyContractGuid = async (
+  partyAddress: string
+): Promise<boolean> => {
+  const key = getEtherscanVerifyContractGuidKey(partyAddress);
+  const res = await getRedisAsync(key);
+  if (res) {
+    console.info(
+      `already verified contract for party ${partyAddress} guid ${res}`
+    );
+    return true;
+  } else {
+    console.info(`have NOT verified contract for party ${partyAddress}`);
+    return false;
+  }
+};
+
+export const setEtherscanVerifyContractGuid = async (
+  partyAddress: string,
+  guid: string
+) => {
+  const key = getEtherscanVerifyContractGuidKey(partyAddress);
+  console.info(
+    `setting etherscan contract verification guid ${guid} for party ${partyAddress}`
+  );
+  await setRedisAsync(key, guid);
+};
+
+export const getEtherscanVerifyProxyContractGuid = async (
+  partyAddress: string
+): Promise<boolean> => {
+  const key = getEtherscanVerifyProxyContractGuidKey(partyAddress);
+  const res = await getRedisAsync(key);
+  if (res) {
+    console.info(
+      `already verified proxy contract for party ${partyAddress} guid ${res}`
+    );
+    return true;
+  } else {
+    console.info(`have NOT verified proxy contract for party ${partyAddress}`);
+    return false;
+  }
+};
+
+export const setEtherscanVerifyProxyContractGuid = async (
+  partyAddress: string,
+  guid: string
+) => {
+  const key = getEtherscanVerifyProxyContractGuidKey(partyAddress);
+  console.info(
+    `setting etherscan proxy contract verification guid ${guid} for party ${partyAddress}`
+  );
+  await setRedisAsync(key, guid);
+};

--- a/src/etherscan/index.ts
+++ b/src/etherscan/index.ts
@@ -8,8 +8,16 @@ const etherscanTasks = async (event: PartyEvent) => {
     await verifyCollectionPartyContractForEvent(event);
   }
 
-  // verify the proxy contract for the party contract
-  await verifyProxyContractForEvent(event);
+  // do not attempt to verify the proxy contract on the start party event. this is to
+  // prevent a race condition where the we attempt to verify the contract source and
+  // proxy contract source at the same time. the party contract must be verified before
+  // the proxy contract can be verified. it takes a considerable amount of time to
+  // verify the party contract, therefore verifying the party contract and proxy contract
+  // at the same time will always result in the proxy contract not being verified.
+  if (event.eventType !== "start") {
+    // verify the proxy contract for the party contract
+    await verifyProxyContractForEvent(event);
+  }
 };
 
 export default etherscanTasks;

--- a/src/etherscan/index.ts
+++ b/src/etherscan/index.ts
@@ -9,7 +9,7 @@ const etherscanTasks = async (event: PartyEvent) => {
   }
 
   // do not attempt to verify the proxy contract on the start party event. this is to
-  // prevent a race condition where the we attempt to verify the contract source and
+  // prevent a race condition where we attempt to verify the contract source and
   // proxy contract source at the same time. the party contract must be verified before
   // the proxy contract can be verified. it takes a considerable amount of time to
   // verify the party contract, therefore verifying the party contract and proxy contract

--- a/src/etherscan/verifyProxyContract.ts
+++ b/src/etherscan/verifyProxyContract.ts
@@ -14,7 +14,7 @@ import {
  */
 export const verifyProxyContract = async (
   address: string
-): Promise<{ isSuccess: boolean; guid: string }> => {
+): Promise<{ isSuccess: boolean; guid?: string }> => {
   if (!address) {
     throw new Error("Missing argument: address");
   }

--- a/src/redis_key_util.ts
+++ b/src/redis_key_util.ts
@@ -5,3 +5,11 @@ export const getHaveAlertedAboutNewPartyCacheKey = (
 export const getHaveAlertedAboutPartyHalfwayCacheKey = (
   partyAddress: string
 ): string => `party_halfway_contribution_${partyAddress}`;
+
+export const getEtherscanVerifyContractGuidKey = (
+  partyAddress: string
+): string => `etherscan_verify_contract_guid_${partyAddress}`;
+
+export const getEtherscanVerifyProxyContractGuidKey = (
+  partyAddress: string
+): string => `etherscan_verify_proxy_contract_guid_${partyAddress}`;


### PR DESCRIPTION
add etherscan verification guid to redis after verify a contract and separately after verifying a proxy contract